### PR TITLE
Lazy load images when the viewport changes

### DIFF
--- a/lib/client/components/article/index.js
+++ b/lib/client/components/article/index.js
@@ -3,6 +3,7 @@ import './article.less'
 
 import Section from '../section'
 import ReadMore from '../read-more-link'
+import LazyImages from '../lazy-images'
 
 export default function Article ({ title, expanded, full, doc, onExpand }) {
   let loadingExpandedDoc = (expanded && !full)
@@ -10,7 +11,9 @@ export default function Article ({ title, expanded, full, doc, onExpand }) {
     <article className='Article'>
       <h1 className='Article-title'>{title.replace(/_/g, ' ')}</h1>
       <div className='Article-content'>
-        {!doc ? 'Loading...' : doc.sections.map(Section)}
+        <LazyImages>
+          {!doc ? 'Loading...' : doc.sections.map(Section)}
+        </LazyImages>
       </div>
       <ReadMore title={title} loading={loadingExpandedDoc}
         onExpand={onExpand}/>

--- a/lib/client/components/lazy-images/index.js
+++ b/lib/client/components/lazy-images/index.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import {findDOMNode} from 'react-dom'
+import throttle from 'lodash.throttle'
+
+const THRESHOLD_DEFAULT = 300
+
+export default React.createClass({
+  propTypes: {
+    children: React.PropTypes.array,
+    threshold: React.PropTypes.number
+  },
+  render () {
+    return (
+      <div className='LazyImages'>
+        {this.props.children}
+      </div>
+    )
+  },
+  componentDidMount () {
+    // Throttle the function that will be bound to the scroll & resize events
+    this.onViewportChange = throttle(this.onViewportChange, THRESHOLD_DEFAULT)
+    window.addEventListener('scroll', this.onViewportChange)
+    window.addEventListener('resize', this.onViewportChange)
+    this.onViewportChange()
+  },
+  componentDidUpdate () {
+    this.onViewportChange()
+  },
+  componentWillUnmount () {
+    window.removeEventListener('scroll', this.onViewportChange)
+    window.removeEventListener('resize', this.onViewportChange)
+  },
+  onViewportChange () {
+    const imagePlaceholders = findDOMNode(this).querySelectorAll('.LootTransformedImage')
+    const threshold = this.props.threshold || 200
+    const innerHeight = window.innerHeight
+
+    Array.prototype.slice.call(imagePlaceholders).forEach((placeholder) => {
+      let bounds = placeholder.getBoundingClientRect()
+      if (
+        // Bottom border is inside viewport from above
+        bounds.top + bounds.height > -threshold &&
+        // Top border is inside viewport from below
+        bounds.top - threshold < innerHeight
+      ) {
+        // Placeholder is visible. Transform it to real image.
+        transformFakeImage(placeholder)
+      }
+    })
+  }
+})
+
+function transformFakeImage (imagePlaceholder) {
+  // Remove the class that identifies that the image is not loaded
+  imagePlaceholder.classList.remove('LootTransformedImage')
+  // Set the real image inside the placeholder.
+  // Avoids reflows since the placeholder has width & height set. If we were to
+  // replaceChild the wrapper with the image, it would cause a reflow and
+  // visible jerkiness on the DOM.
+  imagePlaceholder.innerHTML = imagePlaceholder.dataset.replaceWith
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "history": "^1.13.0",
     "isomorphic-fetch": "^2.2.0",
     "localforage": "^1.3.0",
+    "lodash.throttle": "^3.0.4",
     "normalize.css": "^3.0.3",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",


### PR DESCRIPTION
...because of scroll or resize events, and when mounting or updating a component.

Depends on https://github.com/joakin/loot/pull/35 since the transformation is
dependent on the markup that the loot server returns.

Implemented as a wrapper component. Seems the best way to keep the logic isolated without mixing it with other components logic.

Applied at the Article component level so that we only bind one scroll & resize events (if bound to the sections we would bound one per section, which is not cool).
