### PR TITLE
Import babel-polyfill for safari compatibility

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -1,3 +1,5 @@
+import 'babel-polyfill'
+
 import React from 'react'
 import { Router } from 'react-router'
 import { Provider } from 'react-redux'

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "webpack-hot-middleware": "^2.6.0"
   },
   "dependencies": {
+    "babel-polyfill": "^6.2.0",
     "ecstatic": "^1.3.1",
     "ejs": "^2.3.4",
     "express": "^4.13.3",


### PR DESCRIPTION
Site was broken in safari 8 and iOS.

Adding the polyfill fixes this.
