### PR TITLE
Add LastModifiedBar

### DIFF
--- a/lib/client/components/article/index.js
+++ b/lib/client/components/article/index.js
@@ -2,11 +2,13 @@ import React from 'react'
 import Section from '../section'
 import ReadMore from '../read-more-link'
 import LazyImages from '../lazy-images'
+import LastModifiedBar from '../../components/last-modified'
 
 import './article.less'
 
 export default function Article ({ title, expanded, full, doc, onExpand }) {
   let loadingExpandedDoc = (expanded && !full)
+  let lastmodified = doc.lastmodified
   return (
     <article className='Article'>
       <h1 className='Article-title'>{title.replace(/_/g, ' ')}</h1>
@@ -18,6 +20,7 @@ export default function Article ({ title, expanded, full, doc, onExpand }) {
       </div>
       <ReadMore title={title} loading={loadingExpandedDoc}
         onExpand={onExpand}/>
+      <LastModifiedBar title={title} editor={lastmodified.by} timestamp={lastmodified.at}/>
     </article>
   )
 }

--- a/lib/client/components/last-modified/index.js
+++ b/lib/client/components/last-modified/index.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import timeago from 'timeago'
+import './last-modified.less'
+
+export default React.createClass({
+  propTypes: {
+    editor: React.PropTypes.object,
+    title: React.PropTypes.string,
+    timestamp: React.PropTypes.string
+  },
+  render: function () {
+    const isAnon = this.props.editor.isAnonymous
+    const historyUrl = `https://en.m.wikipedia.org/wiki/Special:History/${this.props.title}`
+    const editorUrl = isAnon ? `https://en.m.wikipedia.org/wiki/Special:Contributions/{$editorName}`
+        : `https://en.m.wikipedia.org/wiki/Special:UserProfile/{$editorName}`
+    const editorLabel = isAnon ? 'an anonymous user' : this.props.editor.name
+    const historyText = 'Last edited ' + timeago(new Date(this.props.timestamp))
+
+    return (
+      <div className='LastModified active'>
+        <a href={historyUrl}>{historyText}</a> by <a href={editorUrl} className='username'>{editorLabel}</a>
+      </div>
+    )
+  }
+})

--- a/lib/client/components/last-modified/last-modified.less
+++ b/lib/client/components/last-modified/last-modified.less
@@ -1,0 +1,25 @@
+@import '../styles/mixins.less';
+
+.LastModified {
+  clear: both;
+  margin-top: 1.5em;
+  padding: 5px 16px;
+  background-color: #eeeeee;
+  font-size: 0.9em;
+  color: #666666;
+  transition: background-color 0.2s ease,color 0.2s ease;
+  .truncated-text();
+
+  a {
+    text-decoration: none;
+  }
+  a,
+  a:visited {
+    color: #666666;
+  }
+
+  .username,
+  .username:visited {
+     font-weight: bold;
+  }
+}

--- a/lib/client/components/styles/mixins.less
+++ b/lib/client/components/styles/mixins.less
@@ -1,5 +1,11 @@
 /* Mobile first queries */
 
+.truncated-text() {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .larger-than-mobile(@rules) {
   @media (min-width: 400px) { @rules(); }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "snazzy": "^2.0.1",
     "standard": "^5.4.1",
     "style-loader": "^0.13.0",
+    "timeago": "^0.2.0",
     "url-loader": "^0.5.7",
     "webpack-dev-middleware": "^1.4.0",
     "webpack-hot-middleware": "^2.6.0"


### PR DESCRIPTION
Do the bare minimum that is legally required - link to article
history page on English Wikipedia (existing mobile)

Add support for 'Last edited by Username' (username linking to
Special:Userprofile) - this is currently not wired up. In future
we could load this on scroll - in most cases it's not actually necessary
just being an enhancement.

Changes:
- Add truncated text mixin

Fixes: #29
