### PR TITLE
Properly proxy api requests

### DIFF
--- a/lib/server/routes.js
+++ b/lib/server/routes.js
@@ -19,8 +19,10 @@ router.all('/api/*', (req, res) => {
   if (splat == null) {
     error('noope', res)
   } else {
-    http.get(api.url(splat), (apiRes) => { res.status(200); apiRes.pipe(res) })
-      .on('error', (e) => error(e.message, res))
+    http.get(api.url(splat), (apiRes) => {
+      res.writeHead(apiRes.statusCode, apiRes.headers)
+      apiRes.pipe(res)
+    }).on('error', (e) => error(e.message, res))
   }
 })
 


### PR DESCRIPTION
Propagate headers and status code from the proxied response so that all
responses work (301s, etc)

Going to localhost:7002/wiki/Fecal would just return a 200 without headers so the redirects from loot wouldn't be proxied.
