### PR TITLE
Enable gzip compression

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -1,5 +1,5 @@
-import Express from 'express'
-import ecstatic from 'ecstatic'
+import express from 'express'
+import compression from 'compression'
 import webpack from 'webpack'
 import webpackDevMiddleware from 'webpack-dev-middleware'
 // import webpackHotMiddleware from 'webpack-hot-middleware'
@@ -7,7 +7,7 @@ import webpackConfig from '../../webpack/dev.webpack.config'
 
 import router from './routes'
 
-const server = Express()
+const server = express()
 const port = process.env.PORT || 7002
 
 if (process.env.NODE_ENV === 'development') {
@@ -16,10 +16,9 @@ if (process.env.NODE_ENV === 'development') {
   // server.use(webpackHotMiddleware(compiler))
 }
 
-server.use(ecstatic({
-  root: './public',
-  showDir: false
-}))
+server.use(compression())
+
+server.use(express.static('public'))
 
 server.use(router)
 

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -10,13 +10,13 @@ import router from './routes'
 const server = express()
 const port = process.env.PORT || 7002
 
+server.use(compression())
+
 if (process.env.NODE_ENV === 'development') {
   const compiler = webpack(webpackConfig)
   server.use(webpackDevMiddleware(compiler, { noInfo: true, publicPath: webpackConfig.output.publicPath }))
   // server.use(webpackHotMiddleware(compiler))
 }
-
-server.use(compression())
 
 server.use(express.static('public'))
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.2.0",
+    "compression": "^1.6.0",
     "ecstatic": "^1.3.1",
     "ejs": "^2.3.4",
     "express": "^4.13.3",


### PR DESCRIPTION
Destroys the size of all the routes!

For example Cat went from 1.2mb (html + js initial data) to 228kb.
