### PR TITLE
Fix scrolling not bubbling to window

### DIFF
--- a/lib/client/components/lazy-images/index.js
+++ b/lib/client/components/lazy-images/index.js
@@ -21,17 +21,17 @@ export default React.createClass({
   },
   componentDidMount () {
     // Throttle the function that will be bound to the scroll & resize events
-    this.onViewportChange = throttle(this.onViewportChange, THRESHOLD_DEFAULT)
-    window.addEventListener('scroll', this.onViewportChange)
-    window.addEventListener('resize', this.onViewportChange)
-    this.onViewportChange()
+    this.__onViewportChange = throttle(this.onViewportChange, THRESHOLD_DEFAULT)
+    window.addEventListener('scroll', this.__onViewportChange, true)
+    window.addEventListener('resize', this.__onViewportChange, true)
+    this.__onViewportChange()
   },
   componentDidUpdate () {
     this.onViewportChange()
   },
   componentWillUnmount () {
-    window.removeEventListener('scroll', this.onViewportChange)
-    window.removeEventListener('resize', this.onViewportChange)
+    window.removeEventListener('scroll', this.__onViewportChange)
+    window.removeEventListener('resize', this.__onViewportChange)
   },
   onViewportChange () {
     if (this.isMounted()) {


### PR DESCRIPTION
Since we changed layout/scrolling to happen in the menu container children
instead of the global window, seems like the event wasn't bubbling to window
and the event listeners weren't being triggered.

Fixes #39
