### PR TITLE
Auto load full article

### DIFF
--- a/lib/client/containers/article/index.js
+++ b/lib/client/containers/article/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
 import Article from '../../components/article'
 import CaptureClicks from '../../components/capture-clicks'
 import { changeArticle, expandArticle } from '../../actions.js'
@@ -8,14 +9,15 @@ const ArticleContainer = React.createClass({
   propTypes: {
     params: React.PropTypes.object,
     article: React.PropTypes.object,
-    dispatch: React.PropTypes.func,
-    history: React.PropTypes.object
+    history: React.PropTypes.object,
+    changeArticle: React.PropTypes.func,
+    expandArticle: React.PropTypes.func
   },
   render () {
-    let {article, history} = this.props
+    let {article, history, params, expandArticle} = this.props
     return (!article ? null
       : <CaptureClicks history={history}>
-          <Article {...article} onExpand={this.expandArticle}/>
+          <Article {...article} onExpand={() => expandArticle(params.title)}/>
         </CaptureClicks>)
   },
   statics: {
@@ -24,23 +26,19 @@ const ArticleContainer = React.createClass({
       return store.dispatch(changeArticle(params.title, full))
     }
   },
-  changeArticle (title) {
-    const {dispatch} = this.props
-    dispatch(changeArticle(title)).then(() =>
+  loadArticle (title) {
+    const {changeArticle, expandArticle} = this.props
+    changeArticle(title).then(() =>
       // Automatically trigger to get the full article loaded
-      dispatch(expandArticle(title)))
+      expandArticle(title))
   },
   componentDidMount () {
-    this.changeArticle(this.props.params.title)
+    this.loadArticle(this.props.params.title)
   },
   componentWillReceiveProps (nextProps) {
     if (nextProps.params.title !== this.props.params.title) {
-      this.changeArticle(nextProps.params.title)
+      this.loadArticle(nextProps.params.title)
     }
-  },
-  expandArticle () {
-    const {dispatch, params} = this.props
-    dispatch(expandArticle(params.title))
   }
 })
 
@@ -52,4 +50,8 @@ function selectArticle ({selectedArticle, articles}) {
   return { article: { title: selectedArticle, ...article } }
 }
 
-export default connect(selectArticle)(ArticleContainer)
+function selectActions (dispatch) {
+  return bindActionCreators({ changeArticle, expandArticle }, dispatch)
+}
+
+export default connect(selectArticle, selectActions)(ArticleContainer)

--- a/lib/client/containers/article/index.js
+++ b/lib/client/containers/article/index.js
@@ -24,14 +24,18 @@ const ArticleContainer = React.createClass({
       return store.dispatch(changeArticle(params.title, full))
     }
   },
+  changeArticle (title) {
+    const {dispatch} = this.props
+    dispatch(changeArticle(title)).then(() =>
+      // Automatically trigger to get the full article loaded
+      dispatch(expandArticle(title)))
+  },
   componentDidMount () {
-    const {dispatch, params} = this.props
-    dispatch(changeArticle(params.title))
+    this.changeArticle(this.props.params.title)
   },
   componentWillReceiveProps (nextProps) {
     if (nextProps.params.title !== this.props.params.title) {
-      const {dispatch, params} = nextProps
-      dispatch(changeArticle(params.title))
+      this.changeArticle(nextProps.params.title)
     }
   },
   expandArticle () {


### PR DESCRIPTION
Make the two step loading automatic instead of triggered by user action (clicking read more).

Change was trivial, will be easy to revert if necessary (change `Article.loadArticle` to not trigger `expandArticle`).
