### PR TITLE
Change article loading hit api always for new content.

### DIFF
--- a/lib/client/__tests__/actions.js
+++ b/lib/client/__tests__/actions.js
@@ -136,6 +136,19 @@ describe('Article actions', () => {
         done()
       }).catch(done)
     })
+
+    it('should fetch summary when changing article even if the article is available in memory/db to get fresh content', (done) => {
+      const testDoc = { sections: ['whatever'] }
+      const testDocUpdated = { sections: ['whatever', 'new'] }
+      let store = configureStore({ articles: { asdf: { doc: testDoc } } })
+      mock(api, 'lead').returnWith(Promise.resolve(testDocUpdated))
+      store.dispatch(changeArticle('asdf')).then(() => {
+        assert.equal(api.lead.callCount, 1)
+        assert.equal(api.lead.lastCall.arg, 'asdf')
+        assert.deepEqual(store.getState().articles['asdf'].doc, testDocUpdated)
+        done()
+      }).catch(done)
+    })
   })
 })
 

--- a/lib/client/actions.js
+++ b/lib/client/actions.js
@@ -58,18 +58,11 @@ export function changeArticle (title, full) {
     } else {
       // Else, go for the summary version
       // Get the article from memory/db
-      return dispatch(getArticle(title))
-        .then((article) => {
-          // If never visited article or not fetched
-          if (!article || !article.doc) {
-            // Grab it from the API
-            return dispatch(fetchSummary(title))
-              // And cache it in the DB when received
-              .then(() => {
-                articleDB.set(title, getState().articles[title])
-              })
-          }
-        })
+      return dispatch(getArticle(title)).then((article) =>
+        // Grab it from the API anyway to find if there is updated content
+        dispatch(fetchSummary(title))
+          // And cache it in the DB when received
+          .then(() => articleDB.set(title, getState().articles[title])))
     }
   }
 }
@@ -80,16 +73,12 @@ export function expandArticle (title) {
     dispatch(getArticle(title))
       .then((article) => {
         dispatch({type: EXPAND_ARTICLE, title})
+        // Save expanded state to DB
         articleDB.set(title, getState().articles[title])
-        // If we don't have the full content
-        if (!article || !(article.full && article.doc)) {
-          // Grab it from the API
-          return dispatch(fetchContent(title))
-            // And cache it in the DB when received
-            .then(() => {
-              articleDB.set(title, getState().articles[title])
-            })
-        }
+        // Grab it from the API anyway to find if there is updated content
+        return dispatch(fetchContent(title))
+          // And cache it in the DB when received
+          .then(() => articleDB.set(title, getState().articles[title]))
       })
 }
 


### PR DESCRIPTION
Previous strategy was CACHE FIRST. If there was a cache fail, then go to
network. That meant that fetched content would remain stale forever in cache.

Now it is CACHE FIRST + NETWORK. It'll try to get the article from cache but
always trigger a network request to get updated content if available.
