### PR TITLE
Fix scroll jank on mobile

### DIFF
--- a/lib/client/containers/app/app.less
+++ b/lib/client/containers/app/app.less
@@ -7,10 +7,21 @@ html, body, #content, .App {
 }
 
 .App {
-  overflow: auto;
   background-color: white;
 
-  >.Toasts {
+  .App-viewport {
+    transition: transform 0.25s cubic-bezier(0.175,0.885,0.32,1.275);
+  }
+
+  &.is-menu-open {
+    overflow: hidden;
+
+    .App-viewport {
+      transform: translateX(240px) translateZ(0);
+    }
+  }
+
+  .Toasts {
     position: fixed;
     bottom: 0;
     left: 0;

--- a/lib/client/containers/app/index.js
+++ b/lib/client/containers/app/index.js
@@ -11,24 +11,26 @@ import Menu from '../menu'
 
 import './app.less'
 
-const App = ({children, startSearchSession, showMenu}) => (
-  <Menu>
-    <div className='App'>
-      <Toasts />
-      <Search />
+const App = ({menu, children, startSearchSession, showMenu}) => (
+    <div className={`App ${menu.open ? 'is-menu-open' : ''}`}>
+      <Menu />
 
-      <TopBar>
-        <Icon type={types.MENU} onClick={showMenu}/>
-        <SearchInput disabled focus={false} onClick={startSearchSession} />
-      </TopBar>
-      <div className='App-content'>
-        {children}
+      <div className='App-viewport'>
+        <Toasts />
+        <Search />
+
+        <TopBar>
+          <Icon type={types.MENU} onClick={showMenu}/>
+          <SearchInput disabled focus={false} onClick={startSearchSession} />
+        </TopBar>
+        <div className='App-content'>
+          {children}
+        </div>
       </div>
     </div>
-  </Menu>
 )
 
-function selectState (s) { return s }
+function selectState ({ menu }) { return { menu } }
 function selectActions (dispatch) {
   return bindActionCreators({ startSearchSession, showMenu }, dispatch)
 }

--- a/lib/client/containers/menu/index.js
+++ b/lib/client/containers/menu/index.js
@@ -11,13 +11,10 @@ const menuItems = [
   { label: 'Home', path: '/', icon: types.HOME }
 ]
 
-const MenuContainer = ({ open, hideMenu, children }) => (
+const MenuContainer = ({ open, hideMenu }) => (
   <div className={`MenuContainer ${open ? 'is-open' : ''}`}>
     <Menu items={menuItems} onItemClick={hideMenu}/>
-    <div className='MenuContainer-content'>
-      <div className='MenuContainer-content-overlay' onClick={hideMenu}/>
-      {children}
-    </div>
+    <div className='MenuContainer-content-overlay' onClick={hideMenu}/>
   </div>
 )
 

--- a/lib/client/containers/menu/menu.less
+++ b/lib/client/containers/menu/menu.less
@@ -1,39 +1,28 @@
 @menu-width: 240px;
 
 .MenuContainer {
-  &, .MenuContainer-content {
-    overflow: hidden;
-    width: 100%;
-    height: 100%;
-  }
   .Menu {
     position: fixed;
     z-index: 2;
-    top: 0;
-    bottom: 0;
-    left: 0;
-  }
-  .MenuContainer-content {
+    top: 0; bottom: 0; left: 0;
     transition: transform 0.25s cubic-bezier(0.175,0.885,0.32,1.275);
-    position: relative;
-    z-index: 4;
-    transform: translateX(0px);
+    transform: translateX(-@menu-width) translateZ(0);
+  }
 
-    >.MenuContainer-content-overlay {
-      position: absolute;
-      z-index: 99999;
-      top: 0; left: 0; right: 0; bottom: 0;
-      background-color: rgba(255, 255, 255, 0.7);
-      visibility: hidden;
-    }
+  .MenuContainer-content-overlay {
+    position: fixed;
+    z-index: 1;
+    top: 0; bottom: 0; left: 0; right: 0;
+    background-color: rgba(255, 255, 255, 0.7);
+    visibility: hidden;
   }
 
   &.is-open {
-    .MenuContainer-content {
-      transform: translateX(@menu-width);
-      >.MenuContainer-content-overlay {
-        visibility: visible;
-      }
+    .Menu {
+      transform: translateX(0%);
+    }
+    .MenuContainer-content-overlay {
+      visibility: visible;
     }
   }
 }


### PR DESCRIPTION
Nesting the content inside of the menu and setting overflow auto on the .App
was causing huge jank on mobile chrome when scrolling through long articles and
the lazy loading the images.

Solution is avoid nesting the app content inside the menu container, and
instead keep the menu layers and the content layers (App-viewport) side by side
inside App.

This fixes the scroll jank completely (it took me a lot of debugging and
trying...).

I could only find this bug as a confirmation that I wasn't going crazy:
https://code.google.com/p/chromium/issues/detail?id=540604
